### PR TITLE
Updates insertCSS() cssOrigin param for Chrome

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1570,7 +1570,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "39"
                 },
                 "edge": {
                   "version_added": false


### PR DESCRIPTION
Updates the Chrome compat data for the cssOrigin param within the browser.tabs.insertCSS method.

MDN link: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/insertCSS

Chrome documentation indicating version number introduced: https://developer.chrome.com/extensions/tabs#method-insertCSS

I believe these are the relevant Chromium bug and commit:
https://bugs.chromium.org/p/chromium/issues/detail?id=632009
https://chromium-review.googlesource.com/c/chromium/src/+/778402/7

I've tested on 75.0.3770.100 (Official Build) (64-bit) (cohort: Stable). I've also seen it used in production Chrome extensions. I verified that changing the param value alters behavior as documented. Chrome's behavior matches MDN-documented behavior.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
